### PR TITLE
Fix comment apostrophe

### DIFF
--- a/js/app/app.js
+++ b/js/app/app.js
@@ -5,7 +5,7 @@
 //Initializing the beast.
 var myapp = angular.module('my-web-app', ['ngRoute', 'ngAnimate', 'ngSanitize']);
 
-//Lets pave the way for the beast.
+//Let’s pave the way for the beast.
 myapp.config(function ($routeProvider, $locationProvider) {
     $routeProvider
         .when('/', {


### PR DESCRIPTION
## Summary
- update comment in `app.js` to use the proper apostrophe

## Testing
- `eslint js/app/app.js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687a8ca6706c83289f0bf40a8476a64e