### PR TITLE
feat: dark mode, spring theme toggle, X rebrand

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,172 @@
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "motion/react";
+
+type Theme = "auto" | "light" | "dark";
+
+const ORDER: Theme[] = ["auto", "light", "dark"];
+
+const LABEL: Record<Theme, string> = {
+  auto: "Auto",
+  light: "Light",
+  dark: "Dark",
+};
+
+function Sun() {
+  return (
+    <svg
+      width="16" height="16" viewBox="0 0 24 24"
+      fill="none" stroke="currentColor" strokeWidth="2"
+      strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+function Moon() {
+  return (
+    <svg
+      width="15" height="15" viewBox="0 0 24 24"
+      fill="none" stroke="currentColor" strokeWidth="2"
+      strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+function System() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M12 3a9 9 0 0 1 0 18z" fill="currentColor" />
+      <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" strokeWidth="2" />
+      <line x1="12" y1="3" x2="12" y2="21" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+const ICON: Record<Theme, () => JSX.Element> = {
+  auto: System,
+  light: Sun,
+  dark: Moon,
+};
+
+function applyTheme(theme: Theme) {
+  if (theme === "auto") {
+    document.documentElement.removeAttribute("data-theme");
+  } else {
+    document.documentElement.setAttribute("data-theme", theme);
+  }
+}
+
+// Spring that settles fast with a barely-perceptible overshoot —
+// feels physical without calling attention to itself.
+const SLOT_SPRING = { type: "spring", stiffness: 380, damping: 30 } as const;
+const ICON_SPRING = { type: "spring", stiffness: 400, damping: 28 } as const;
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>("auto");
+  const [expanded, setExpanded] = useState(false);
+  const [isTouch, setIsTouch] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as Theme | null;
+    if (stored && ORDER.includes(stored)) setTheme(stored);
+    setIsTouch(!window.matchMedia("(hover: hover) and (pointer: fine)").matches);
+  }, []);
+
+  function select(t: Theme) {
+    setTheme(t);
+    localStorage.setItem("theme", t);
+    applyTheme(t);
+    setExpanded(false);
+  }
+
+  function handleActiveClick() {
+    if (isTouch) {
+      const sysDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      select(theme === "auto" ? (sysDark ? "light" : "dark") : "auto");
+    }
+  }
+
+  const inactive = ORDER.filter((t) => t !== theme);
+  const ActiveIcon = ICON[theme];
+
+  return (
+    <div
+      className="theme-picker"
+      onMouseEnter={() => !isTouch && setExpanded(true)}
+      onMouseLeave={() => setExpanded(false)}
+    >
+      {/* Inactive options — spring in from the right, snap closed on exit */}
+      <AnimatePresence initial={false}>
+        {expanded &&
+          inactive.map((t, i) => {
+            const Icon = ICON[t];
+            return (
+              <motion.div
+                key={t}
+                style={{ overflow: "hidden", flexShrink: 0, display: "flex" }}
+                initial={{ width: 0, opacity: 0 }}
+                animate={{ width: 34, opacity: 1 }}
+                exit={{
+                  width: 0,
+                  opacity: 0,
+                  transition: {
+                    width: { duration: 0.14, ease: [0.4, 0, 1, 1] },
+                    opacity: { duration: 0.1 },
+                  },
+                }}
+                transition={{
+                  width: { ...SLOT_SPRING, delay: i * 0.045 },
+                  opacity: { duration: 0.1, delay: i * 0.045 },
+                }}
+              >
+                <button
+                  type="button"
+                  className="theme-btn"
+                  onClick={() => select(t)}
+                  aria-label={LABEL[t]}
+                  title={LABEL[t]}
+                >
+                  <Icon />
+                </button>
+              </motion.div>
+            );
+          })}
+      </AnimatePresence>
+
+      {/* Active icon — springs in when the selection changes */}
+      <button
+        type="button"
+        className="theme-btn theme-btn--on"
+        onClick={handleActiveClick}
+        aria-label={`Theme: ${LABEL[theme]}`}
+        title={`Theme: ${LABEL[theme]}`}
+      >
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.span
+            key={theme}
+            style={{ display: "flex", alignItems: "center", justifyContent: "center" }}
+            initial={{ scale: 0.5, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.5, opacity: 0, transition: { duration: 0.08 } }}
+            transition={ICON_SPRING}
+          >
+            <ActiveIcon />
+          </motion.span>
+        </AnimatePresence>
+      </button>
+    </div>
+  );
+}

--- a/src/data/profile.json
+++ b/src/data/profile.json
@@ -12,9 +12,9 @@
         "alt": "Connect with me on Facebook"
       },
       {
-        "name": "twitter",
-        "url": "https://twitter.com/rishi_gohil10",
-        "alt": "Connect with me on Twitter"
+        "name": "x",
+        "url": "https://x.com/rishi_gohil10",
+        "alt": "Connect with me on X"
       },
       {
         "name": "linkedin",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/clothes.css";
 import { ClientRouter } from "astro:transitions";
+import ThemeToggle from "../components/ThemeToggle";
 
 interface Props {
   title?: string;
@@ -55,6 +56,23 @@ const ogImageUrl = new URL("/mypic.jpg", Astro.site).toString();
     <title>{title}</title>
     <ClientRouter />
 
+    <!-- Apply saved theme before first paint to avoid flash -->
+    <script is:inline>
+      (function () {
+        function applyTheme() {
+          var t = localStorage.getItem("theme");
+          var html = document.documentElement;
+          if (t === "light" || t === "dark") {
+            html.setAttribute("data-theme", t);
+          } else {
+            html.removeAttribute("data-theme");
+          }
+        }
+        applyTheme();
+        document.addEventListener("astro:after-swap", applyTheme);
+      })();
+    </script>
+
     <!-- Google tag (gtag.js) -->
     <script
       is:inline
@@ -84,6 +102,7 @@ const ogImageUrl = new URL("/mypic.jpg", Astro.site).toString();
     </script>
   </head>
   <body>
+    <ThemeToggle client:load />
     <main id="main">
       <slot />
     </main>

--- a/src/styles/clothes.css
+++ b/src/styles/clothes.css
@@ -14,6 +14,75 @@
     "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 }
 
+/* ──────────────────────────────────────────────────────────────
+   Theme tokens — light defaults, dark overrides.
+   ────────────────────────────────────────────────────────────── */
+:root {
+  --color-bg:            #ffffff;
+  --color-surface:       #ffffff;
+  --color-surface-hover: #ffffff;   /* card bg on hover — same in light (shadow does the work) */
+  --color-text-1:        #18181b;
+  --color-text-2:        #27272a;
+  --color-text-bio:      #333333;
+  --color-text-muted:    #71717a;
+  --color-text-subtle:   #3f3f46;
+  --color-border:        #d4d4d8;
+  --color-footer:        #b1b1b1;
+  --color-ring:          rgba(0, 0, 0, 0.06);
+  --color-ring-hover:    rgba(0, 0, 0, 0.10);
+  --shadow-card:         0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+  --shadow-card-hover:   0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
+  color-scheme:          light;
+}
+
+/* System dark mode (when theme is "auto" / unset). */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --color-bg:            #09090b;
+    --color-surface:       #18181b;
+    --color-surface-hover: #27272a;   /* card lightens slightly on hover — sells the "closer" illusion */
+    --color-text-1:        #f4f4f5;
+    --color-text-2:        #e4e4e7;
+    --color-text-bio:      #d4d4d8;
+    --color-text-muted:    #a1a1aa;
+    --color-text-subtle:   #a1a1aa;
+    --color-border:        #3f3f46;
+    --color-footer:        #52525b;
+    --color-ring:          rgba(255, 255, 255, 0.06);
+    --color-ring-hover:    rgba(255, 255, 255, 0.12);
+    --shadow-card:         0 1px 3px rgba(0, 0, 0, 0.5), 0 1px 2px rgba(0, 0, 0, 0.6);
+    /* Three-layer lift for dark mode:
+       1. deep drop shadow (still contributes some depth near edges)
+       2. thin outer ring (card outline separates from the background)
+       3. inset top-edge catch (simulates ambient light from above hitting the raised surface) */
+    --shadow-card-hover:   0 20px 40px rgba(0, 0, 0, 0.9),
+                           0 0 0 1px rgba(255, 255, 255, 0.07),
+                           inset 0 1px 0 rgba(255, 255, 255, 0.07);
+    color-scheme:          dark;
+  }
+}
+
+/* Explicit dark override. */
+[data-theme="dark"] {
+  --color-bg:            #09090b;
+  --color-surface:       #18181b;
+  --color-surface-hover: #27272a;
+  --color-text-1:        #f4f4f5;
+  --color-text-2:        #e4e4e7;
+  --color-text-bio:      #d4d4d8;
+  --color-text-muted:    #a1a1aa;
+  --color-text-subtle:   #a1a1aa;
+  --color-border:        #3f3f46;
+  --color-footer:        #52525b;
+  --color-ring:          rgba(255, 255, 255, 0.06);
+  --color-ring-hover:    rgba(255, 255, 255, 0.12);
+  --shadow-card:         0 1px 3px rgba(0, 0, 0, 0.5), 0 1px 2px rgba(0, 0, 0, 0.6);
+  --shadow-card-hover:   0 20px 40px rgba(0, 0, 0, 0.9),
+                         0 0 0 1px rgba(255, 255, 255, 0.07),
+                         inset 0 1px 0 rgba(255, 255, 255, 0.07);
+  color-scheme:          dark;
+}
+
 html,
 body {
   font-family: var(--font-sans);
@@ -21,11 +90,18 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* The dotted SVG background — lifted verbatim from the original
-   clothes.css. White-on-white can't read; this gives the page a pulse. */
+/* Dotted background — dot color shifts with the theme. */
 body {
-  background-color: #ffffff;
+  background-color: var(--color-bg);
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cpath fill='%23d8d8d8' fill-opacity='0.3' d='M1 3h1v1H1V3zm2-2h1v1H3V1z'%3E%3C/path%3E%3C/svg%3E");
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) body {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cpath fill='%233f3f46' fill-opacity='0.4' d='M1 3h1v1H1V3zm2-2h1v1H3V1z'%3E%3C/path%3E%3C/svg%3E");
+  }
+}
+[data-theme="dark"] body {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cpath fill='%233f3f46' fill-opacity='0.4' d='M1 3h1v1H1V3zm2-2h1v1H3V1z'%3E%3C/path%3E%3C/svg%3E");
 }
 
 /* Page-to-page costume changes — snappy, no fashion show. */
@@ -52,18 +128,18 @@ body {
 .not-found h2 {
   font-size: 1.875rem;
   font-weight: 500;
-  color: #18181b;
+  color: var(--color-text-1);
   margin: 0;
 }
 .not-found h4 {
   margin-top: 1rem;
   font-size: 1.125rem;
-  color: #27272a;
+  color: var(--color-text-2);
 }
 .not-found h5 {
   margin-top: 0.5rem;
   font-size: 1rem;
-  color: #3f3f46;
+  color: var(--color-text-subtle);
 }
 .not-found .actions {
   margin-top: 1.5rem;
@@ -80,20 +156,22 @@ body {
   width: 300px;
   max-width: 95%;
   margin: 1rem;
-  background: #ffffff;
+  background: var(--color-surface);
   border-radius: 8px;
   text-align: center;
-  box-shadow:
-    0 1px 3px rgba(0, 0, 0, 0.12),
-    0 1px 2px rgba(0, 0, 0, 0.24);
-  transition: all 0.7s cubic-bezier(0.25, 0.8, 0.25, 1);
+  box-shadow: var(--shadow-card);
+  transition:
+    box-shadow 0.7s cubic-bezier(0.25, 0.8, 0.25, 1),
+    transform 0.7s cubic-bezier(0.25, 0.8, 0.25, 1),
+    background-color 0.4s ease;
 }
-/* On hover the card stands four pixels taller, like it heard a compliment. */
+/* On hover the card stands four pixels taller, like it heard a compliment.
+   In dark mode the shadow alone reads flat, so the background also lightens
+   slightly — the card surface "comes closer" as it rises. */
 .card:hover {
-  box-shadow:
-    0 14px 28px rgba(0, 0, 0, 0.25),
-    0 10px 10px rgba(0, 0, 0, 0.22);
+  box-shadow: var(--shadow-card-hover);
   transform: translate(0, -4px);
+  background: var(--color-surface-hover);
 }
 
 /* ──────────────────────────────────────────────────────────────
@@ -107,13 +185,13 @@ body {
   margin: 0.5rem 0 0;
   font-size: 18px;
   font-weight: 500;
-  color: #18181b;
+  color: var(--color-text-1);
 }
 .summary .heading {
   margin: 0;
   font-size: 0.875rem;
   font-weight: 400;
-  color: grey;
+  color: var(--color-text-muted);
 }
 
 /* Profile picture — a small ring of confidence that grows when
@@ -125,11 +203,11 @@ body {
   width: 120px;
   border-radius: 50%;
   background: url("/mypic.jpg") no-repeat center / cover;
-  box-shadow: 0 0 0 8px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 0 0 8px var(--color-ring);
   transition: box-shadow 0.3s ease;
 }
 .dp-container:hover {
-  box-shadow: 0 0 0 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 0 12px var(--color-ring-hover);
 }
 
 /* ──────────────────────────────────────────────────────────────
@@ -139,7 +217,7 @@ body {
 .bio {
   display: block;
   padding: 1rem 1.25rem 0;
-  color: #333333;
+  color: var(--color-text-bio);
 }
 .bio p {
   margin: 0 0 1.5rem;
@@ -148,7 +226,7 @@ body {
   font-weight: 700;
   position: relative;
   cursor: pointer;
-  color: #000;
+  color: var(--color-text-1);
   text-decoration: none;
 }
 .bio a::before,
@@ -158,7 +236,7 @@ body {
   width: 0;
   height: 2px;
   bottom: -2px;
-  background: #000;
+  background: var(--color-text-1);
 }
 .bio a::before {
   left: 0;
@@ -195,10 +273,10 @@ body {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  border: 1px solid #d4d4d8;
+  border: 1px solid var(--color-border);
   border-radius: 0.25rem;
   background: transparent;
-  color: #3f3f46;
+  color: var(--color-text-subtle);
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -211,8 +289,8 @@ body {
     background-color 0.2s ease;
 }
 .button:hover {
-  border-color: #18181b;
-  color: #18181b;
+  border-color: var(--color-text-1);
+  color: var(--color-text-1);
 }
 .button-square {
   width: 40px;
@@ -260,7 +338,7 @@ body {
   justify-content: center;
   width: 36px;
   height: 36px;
-  color: #000;
+  color: var(--color-text-1);
   text-decoration: none;
   transition:
     background-color 0.5s ease,
@@ -274,13 +352,13 @@ body {
   background-color: #3d5b99;
 } /* navy, predictably. */
 
-.icon-twitter {
-  --icon-mask: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M22.46 6c-.77.35-1.6.58-2.46.69a4.3 4.3 0 0 0 1.88-2.37 8.59 8.59 0 0 1-2.72 1.04 4.28 4.28 0 0 0-7.4 3.9A12.14 12.14 0 0 1 3 4.79a4.28 4.28 0 0 0 1.32 5.71 4.27 4.27 0 0 1-1.94-.54v.05a4.28 4.28 0 0 0 3.43 4.2 4.3 4.3 0 0 1-1.93.07 4.28 4.28 0 0 0 4 2.97A8.6 8.6 0 0 1 2 19.07a12.13 12.13 0 0 0 6.57 1.93c7.88 0 12.2-6.53 12.2-12.2 0-.19 0-.37-.01-.56A8.7 8.7 0 0 0 22.46 6z'/%3E%3C/svg%3E");
+.icon-x {
+  --icon-mask: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z'/%3E%3C/svg%3E");
 }
-.icon-twitter:hover {
+.icon-x:hover {
   color: #fff;
-  background-color: #00aced;
-} /* the original Twitter blue — before the rebrand and the lawyers. */
+  background-color: #000;
+}
 
 .icon-linkedin {
   --icon-mask: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M20.45 20.45h-3.55v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.13 1.45-2.13 2.94v5.67H9.36V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.06 2.06 0 1 1 0-4.12 2.06 2.06 0 0 1 0 4.12zM7.12 20.45H3.56V9h3.56v11.45zM22.22 0H1.78C.79 0 0 .77 0 1.72v20.56C0 23.23.79 24 1.78 24h20.44c.99 0 1.78-.77 1.78-1.72V1.72C24 .77 23.21 0 22.22 0z'/%3E%3C/svg%3E");
@@ -344,6 +422,58 @@ body {
 }
 
 /* ──────────────────────────────────────────────────────────────
+   Theme picker — top-right corner.
+   Slot expansion and icon transitions are spring-animated in
+   ThemeToggle.tsx (Framer Motion). CSS owns only static geometry
+   and the subtle border/shadow lift on hover.
+   ────────────────────────────────────────────────────────────── */
+.theme-picker {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-surface);
+  overflow: hidden;
+  z-index: 10;
+  transition:
+    border-color 0.25s ease,
+    box-shadow 0.25s ease;
+}
+
+.theme-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s ease;
+}
+
+.theme-btn:hover {
+  color: var(--color-text-1);
+}
+
+.theme-btn--on {
+  color: var(--color-text-1);
+}
+
+@media (hover: hover) {
+  .theme-picker:hover {
+    border-color: var(--color-text-muted);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────
    Site footer — small, grey, sits in the corner like it's nine
    o'clock on a Tuesday. Mirrors the legacy `.footer`.
    ────────────────────────────────────────────────────────────── */
@@ -354,7 +484,7 @@ body {
   padding: 1rem;
   text-align: left;
   font-size: 10px;
-  color: #b1b1b1;
+  color: var(--color-footer);
 }
 @media (max-width: 550px) {
   .site-footer {
@@ -411,10 +541,14 @@ body {
     transform: none;
   }
   .icon,
-  .button {
+  .button,
+  .theme-picker {
     color: #000 !important;
     background: transparent !important;
     border-color: #000 !important;
+  }
+  .theme-picker {
+    box-shadow: none !important;
   }
   a[href]::after {
     content: " (" attr(href) ")";


### PR DESCRIPTION
## Summary

- **Dark mode** — full light / dark / auto (system) theme support via CSS custom properties. A no-flash inline script applies the saved preference before first paint; Astro view transitions preserve the choice across page navigations.
- **Theme toggle** — `ThemeToggle` component (top-right corner) unfurls into three icon buttons on desktop hover using Framer Motion spring physics (slot expansion + icon crossfade pop). On touch it smart-toggles between auto and the opposite of the current system preference.
- **Dark mode card hover** — three-layer shadow (deep drop + 1 px outer ring + inset top-edge catch) and a subtle surface lightening so the lift effect reads on a dark background, not just light.
- **X rebrand** — Twitter bird replaced with the official X wordmark SVG; URL updated to `x.com`.

## Test plan

- [ ] Light mode: card hover shadow lifts clearly
- [ ] Dark mode: card hover shows lift (surface lightens + ring visible)
- [ ] Toggle cycles auto → light → dark on desktop hover + click
- [ ] Toggle respects system preference in auto mode
- [ ] Preference persists across page reloads (localStorage)
- [ ] No flash of wrong theme on load
- [ ] Touch device: single-icon smart toggle works
- [ ] X icon renders and links to x.com/rishi_gohil10

🤖 Generated with [Claude Code](https://claude.com/claude-code)